### PR TITLE
Scaffold SolidResume Hugo CV site

### DIFF
--- a/assets/css/print.css
+++ b/assets/css/print.css
@@ -1,0 +1,8 @@
+@media print {
+  :root { --bg: #ffffff; --fg: #000000; --border: #000000; }
+  body { background: var(--bg); color: var(--fg); }
+  a { color: inherit; text-decoration: none; }
+  .theme-toggle, .no-print { display: none !important; }
+  @page { size: A4; margin: 12mm; }
+  .container { max-width: none; padding: 0; }
+}

--- a/assets/css/site.css
+++ b/assets/css/site.css
@@ -1,0 +1,43 @@
+:root {
+  color-scheme: light dark;
+  --bg: #ffffff;
+  --fg: #111111;
+  --muted: #666666;
+  --accent: #0b5fff;
+  --border: #e5e7eb;
+}
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg: #0b0e14;
+    --fg: #e6e6e6;
+    --muted: #9aa0a6;
+    --accent: #7aa2ff;
+    --border: #1f2937;
+  }
+}
+html, body {
+  margin: 0; padding: 0;
+  background: var(--bg); color: var(--fg);
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+  line-height: 1.55;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+a { color: var(--accent); text-decoration: none; }
+a:hover { text-decoration: underline; }
+.container {
+  max-width: 840px; margin: 2rem auto; padding: 0 1rem;
+}
+header { display:flex; justify-content: space-between; align-items: center; gap: 1rem; }
+h1, h2, h3 { line-height:1.25; margin: 1.25rem 0 .5rem; }
+.section { padding: 1rem 0; border-top: 1px solid var(--border); }
+.meta { color: var(--muted); font-size: .9rem; }
+.list { margin: .5rem 0 0 0; padding-left: 1.25rem; }
+.badge { display:inline-block; border:1px solid var(--border); border-radius:.5rem; padding:.15rem .5rem; margin:.15rem; font-size:.85rem; }
+.theme-toggle {
+  border:1px solid var(--border); background: transparent; color: var(--fg);
+  border-radius:.5rem; padding:.4rem .6rem; cursor: pointer;
+}
+@media (max-width: 600px){
+  .container { margin: 1rem auto; }
+}

--- a/config/_default/hugo.toml
+++ b/config/_default/hugo.toml
@@ -1,0 +1,36 @@
+baseURL = "/"
+languageCode = "en"
+title = "SolidResume"
+defaultContentLanguage = "en"
+defaultContentLanguageInSubdir = true
+enableRobotsTXT = true
+paginate = 1
+disableKinds = ["taxonomy", "term", "section"] # can re-enable sitemap later
+
+[outputs]
+home = ["HTML", "RSS", "JSON"]
+
+[params]
+siteDescription = "SolidResume — single-page CV powered by Hugo"
+colorScheme = "auto" # auto|light|dark
+printVersion = true
+
+[markup.goldmark.renderer]
+unsafe = true
+
+[privacy]
+  [privacy.youtube]
+  disabled = true
+  [privacy.twitter]
+  disabled = true
+
+[languages]
+  [languages.en]
+    languageName = "English"
+    weight = 1
+    title = "CV — Peter Gibbons"
+
+  [languages.nb]
+    languageName = "Norsk"
+    weight = 2
+    title = "CV — Peter Gibbons"

--- a/data/cv/en.yaml
+++ b/data/cv/en.yaml
@@ -1,0 +1,68 @@
+# Dummy Office Space-style data. Any top-level section can be removed;
+# templates only render sections that exist and are non-empty.
+profile:
+  name: "Peter Gibbons"
+  role: "Software Engineer (TPS Reports Averse)"
+  location: "Austin, TX"
+  email: "peter.gibbons@example.com"
+  url: "https://initech.example.com/~pgibbons"
+  summary: >
+    Results-oriented engineer who believes in removing unnecessary bureaucracy,
+    simplifying processes, and protecting staplers at all costs.
+  links:
+    - label: "LinkedIn"
+      url: "https://www.linkedin.com/in/petergibbons"
+    - label: "GitHub"
+      url: "https://github.com/pgibbons"
+
+# Remove 'experience' entirely or make it an empty list to hide the section.
+experience:
+  - company: "Initech"
+    role: "Software Engineer"
+    start: "1999-01"
+    end: "2001-05"
+    summary: >
+      Contributed to mission-critical Y2K efforts and TPS report cover-sheet standardization.
+    bullets:
+      - "Optimized weekend workloads by eliminating unnecessary Saturday shifts"
+      - "Chaired the Anti-Printer-Jam Working Group"
+  - company: "Initrode"
+    role: "Junior Developer"
+    start: "1997-06"
+    end: "1998-12"
+    summary: >
+      Assisted with enterprise integrations and coffee machine uptime initiatives.
+    bullets:
+      - "Implemented robust cover sheet reminder system"
+      - "Reduced printer-induced rage incidents by 42%"
+
+education:
+  - school: "Southwest Texas State University"
+    degree: "B.Sc. in Computer Science"
+    start: "1993"
+    end: "1997"
+
+projects:
+  - name: "TPS Cover Sheet Generator"
+    url: "https://example.com/tps"
+    summary: "CLI + web utility to ensure every TPS report has a compliant cover sheet."
+  - name: "Printer Jam Predictor"
+    url: "https://example.com/pjp"
+    summary: "Naive Bayes model predicting paper jam risk with questionable accuracy."
+
+skills:
+  - "Go"
+  - "Hugo"
+  - "Process Simplification"
+  - "Printer Decommissioning"
+
+spoken_languages:
+  - name: "English"
+    level: "Native"
+  - name: "Norwegian"
+    level: "Casual 'hei' level"
+
+# Optional contact block; if removed, Contact will not render.
+contact:
+  email: "peter.gibbons@example.com"
+  website: "https://initech.example.com/~pgibbons"

--- a/data/cv/nb.yaml
+++ b/data/cv/nb.yaml
@@ -1,0 +1,55 @@
+profile:
+  name: "Peter Gibbons"
+  role: "Programmerer (Allergisk mot TPS-skjema)"
+  location: "Austin, Texas"
+  email: "peter.gibbons@example.com"
+  url: "https://initech.example.com/~pgibbons"
+  summary: >
+    Praktisk anlagt utvikler som liker å kutte unødig byråkrati, forenkle prosesser
+    og beskytte røde stiftemaskiner.
+  links:
+    - label: "LinkedIn"
+      url: "https://www.linkedin.com/in/petergibbons"
+    - label: "GitHub"
+      url: "https://github.com/pgibbons"
+
+experience:
+  - company: "Initech"
+    role: "Programmerer"
+    start: "1999-01"
+    end: "2001-05"
+    summary: >
+      Bidro til kritiske Y2K-tiltak og standardisering av forsideark for TPS-rapporter.
+    bullets:
+      - "Optimaliserte helgearbeid ved å fjerne unødvendige lørdagsøkter"
+      - "Ledet arbeidsgruppe mot papirstopp i printere"
+
+education:
+  - school: "Southwest Texas State University"
+    degree: "Bachelor i informatikk"
+    start: "1993"
+    end: "1997"
+
+projects:
+  - name: "TPS Cover Sheet Generator"
+    url: "https://example.com/tps"
+    summary: "Verktøy for å sikre at alle TPS-rapporter har korrekt forside."
+  - name: "Printer Jam Predictor"
+    url: "https://example.com/pjp"
+    summary: "Enkel modell som forsøker å forutse papirstopp."
+
+skills:
+  - "Go"
+  - "Hugo"
+  - "Prosessforenkling"
+  - "Printer-sanering"
+
+spoken_languages:
+  - name: "Engelsk"
+    level: "Morsmål"
+  - name: "Norsk"
+    level: "Grunnleggende"
+
+contact:
+  email: "peter.gibbons@example.com"
+  website: "https://initech.example.com/~pgibbons"

--- a/hugo.toml
+++ b/hugo.toml
@@ -1,3 +1,0 @@
-baseURL = 'https://example.org/'
-languageCode = 'en-us'
-title = 'My New Hugo Site'

--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -1,0 +1,16 @@
+[about]
+other = "About"
+[experience]
+other = "Experience"
+[education]
+other = "Education"
+[projects]
+other = "Projects"
+[skills]
+other = "Skills"
+[languages]
+other = "Languages"
+[contact]
+other = "Contact"
+[download_pdf]
+other = "Download PDF"

--- a/i18n/nb.toml
+++ b/i18n/nb.toml
@@ -1,0 +1,16 @@
+[about]
+other = "Om meg"
+[experience]
+other = "Erfaring"
+[education]
+other = "Utdanning"
+[projects]
+other = "Prosjekter"
+[skills]
+other = "Ferdigheter"
+[languages]
+other = "Språk"
+[contact]
+other = "Kontakt"
+[download_pdf]
+other = "Last ned PDF"

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -1,0 +1,62 @@
+<!doctype html>
+<html lang="{{ .Site.Language.Lang }}">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="description" content="{{ .Site.Params.siteDescription }}">
+  {{ partial "head/seo.html" . }}
+  <link rel="icon" href="{{ "favicon.svg" | relURL }}" type="image/svg+xml">
+
+  {{ $site := resources.Get "css/site.css" | minify | fingerprint }}
+  <link rel="stylesheet" href="{{ $site.RelPermalink }}" integrity="{{ $site.Data.Integrity }}" />
+
+  {{ $print := resources.Get "css/print.css" | minify | fingerprint }}
+  <link rel="stylesheet" href="{{ $print.RelPermalink }}" integrity="{{ $print.Data.Integrity }}" media="print" />
+
+  {{ partial "head/ld-json.html" . }}
+
+  <link rel="alternate" hreflang="en" href="{{ with .Site.Languages.en }}{{ . | relLangURL "" }}{{ end }}" />
+  <link rel="alternate" hreflang="nb" href="{{ with .Site.Languages.nb }}{{ . | relLangURL "" }}{{ end }}" />
+</head>
+<body>
+  <main class="container" role="main">
+    <header>
+      <div>
+        {{ $cv := index .Site.Data.cv .Site.Language.Lang }}
+        <h1>{{ with $cv.profile.name }}{{ . }}{{ else }}{{ .Site.Title }}{{ end }}</h1>
+        <div class="meta">
+          {{ with $cv.profile.role }}{{ . }}{{ end }}{{ if and $cv.profile.role $cv.profile.location }} · {{ end }}
+          {{ with $cv.profile.location }}{{ . }}{{ end }}
+        </div>
+      </div>
+      {{ partial "theme-toggle.html" . }}
+    </header>
+
+    {{ block "main" . }}{{ end }}
+
+    {{ partial "footer.html" . }}
+  </main>
+
+  <script>
+    (function(){
+      const key = "cv-theme";
+      const root = document.documentElement;
+      const btn = document.querySelector('[data-theme-toggle]');
+      function apply(mode){
+        if(mode === "light"){ root.style.colorScheme = "light"; }
+        else if(mode === "dark"){ root.style.colorScheme = "dark"; }
+        else { root.style.colorScheme = ""; } // auto
+      }
+      const saved = localStorage.getItem(key) || "auto";
+      apply(saved);
+      if(btn){
+        btn.addEventListener('click', () => {
+          const next = saved === "light" ? "dark" : saved === "dark" ? "auto" : "light";
+          localStorage.setItem(key, next);
+          location.reload();
+        });
+      }
+    })();
+  </script>
+</body>
+</html>

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -1,0 +1,97 @@
+{{ define "main" }}
+  {{ $cv := index .Site.Data.cv .Site.Language.Lang }}
+
+  {{ with $cv.profile.summary }}
+  <section class="section" id="about">
+    <h2>{{ i18n "about" }}</h2>
+    <p>{{ . }}</p>
+    {{ with $cv.profile.links }}
+      {{ if gt (len .) 0 }}
+      <p>
+        {{ range $i, $l := . }}
+          <a href="{{ $l.url }}" rel="me">{{ $l.label }}</a>{{ if lt (add $i 1) (len $cv.profile.links) }} · {{ end }}
+        {{ end }}
+      </p>
+      {{ end }}
+    {{ end }}
+  </section>
+  {{ end }}
+
+  {{ with $cv.experience }}
+  {{ if gt (len .) 0 }}
+  <section class="section" id="experience">
+    <h2>{{ i18n "experience" }}</h2>
+    {{ range . }}
+      <h3>{{ .role }}{{ if and .role .company }} — {{ end }}{{ .company }}</h3>
+      <div class="meta">
+        {{ with .start }}{{ . }}{{ end }}{{ if and .start .end }} — {{ end }}{{ with .end }}{{ . }}{{ end }}
+      </div>
+      {{ with .summary }}<p>{{ . }}</p>{{ end }}
+      {{ with .bullets }}{{ if gt (len .) 0 }}<ul class="list">{{ range . }}<li>{{ . }}</li>{{ end }}</ul>{{ end }}{{ end }}
+    {{ end }}
+  </section>
+  {{ end }}
+  {{ end }}
+
+  {{ with $cv.education }}
+  {{ if gt (len .) 0 }}
+  <section class="section" id="education">
+    <h2>{{ i18n "education" }}</h2>
+    {{ range . }}
+      <h3>{{ .degree }}{{ if and .degree .school }} — {{ end }}{{ .school }}</h3>
+      <div class="meta">
+        {{ with .start }}{{ . }}{{ end }}{{ if and .start .end }} — {{ end }}{{ with .end }}{{ . }}{{ end }}
+      </div>
+    {{ end }}
+  </section>
+  {{ end }}
+  {{ end }}
+
+  {{ with $cv.projects }}
+  {{ if gt (len .) 0 }}
+  <section class="section" id="projects">
+    <h2>{{ i18n "projects" }}</h2>
+    {{ range . }}
+      <h3>{{ .name }}{{ with .url }} — <a href="{{ . }}">{{ . }}</a>{{ end }}</h3>
+      {{ with .summary }}<p>{{ . }}</p>{{ end }}
+    {{ end }}
+  </section>
+  {{ end }}
+  {{ end }}
+
+  {{ with $cv.skills }}
+  {{ if gt (len .) 0 }}
+  <section class="section" id="skills">
+    <h2>{{ i18n "skills" }}</h2>
+    <p>{{ range . }}<span class="badge">{{ . }}</span>{{ end }}</p>
+  </section>
+  {{ end }}
+  {{ end }}
+
+  {{ with $cv.spoken_languages }}
+  {{ if gt (len .) 0 }}
+  <section class="section" id="languages">
+    <h2>{{ i18n "languages" }}</h2>
+    <ul class="list">
+      {{ range . }}<li>{{ .name }}{{ with .level }} — {{ . }}{{ end }}</li>{{ end }}
+    </ul>
+  </section>
+  {{ end }}
+  {{ end }}
+
+  {{ with $cv.contact }}
+  <section class="section" id="contact">
+    <h2>{{ i18n "contact" }}</h2>
+    <ul class="list">
+      {{ with .email }}<li><a href="mailto:{{ . }}">{{ . }}</a></li>{{ end }}
+      {{ with .website }}<li><a href="{{ . }}">{{ . }}</a></li>{{ end }}
+    </ul>
+  </section>
+  {{ end }}
+
+  {{ if .Site.Params.printVersion }}
+  <p class="no-print" style="margin-top:1rem;">
+    <a href="javascript:window.print()">{{ i18n "download_pdf" }}</a>
+  </p>
+  {{ end }}
+{{ end }}

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -1,0 +1,3 @@
+<footer class="section">
+  <div class="meta">© {{ now.Format "2006" }} · Generated with Hugo · SolidResume</div>
+</footer>

--- a/layouts/partials/head/ld-json.html
+++ b/layouts/partials/head/ld-json.html
@@ -1,0 +1,15 @@
+{{ $cv := index .Site.Data.cv .Site.Language.Lang }}
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Person"
+  {{ with $cv.profile.name }}, "name": {{ . | jsonify }}{{ end }}
+  {{ with $cv.profile.role }}, "jobTitle": {{ . | jsonify }}{{ end }}
+  {{ with $cv.profile.location }}, "homeLocation": {{ . | jsonify }}{{ end }}
+  {{ with $cv.profile.email }}, "email": {{ . | jsonify }}{{ end }}
+  {{ with $cv.profile.url }}, "url": {{ . | jsonify }}{{ end }}
+  {{ with $cv.profile.links }}
+    {{ if gt (len .) 0 }}, "sameAs": [{{ $links := slice }}{{ range . }}{{ $links = $links | append .url }}{{ end }}{{ delimit (apply $links "jsonify" ".") ", " }}]{{ end }}
+  {{ end }}
+}
+</script>

--- a/layouts/partials/head/seo.html
+++ b/layouts/partials/head/seo.html
@@ -1,0 +1,7 @@
+<title>{{ if .IsHome }}{{ .Site.Title }}{{ else }}{{ .Title }} · {{ .Site.Title }}{{ end }}</title>
+<meta property="og:title" content="{{ .Title }}">
+<meta property="og:site_name" content="{{ .Site.Title }}">
+<meta property="og:type" content="website">
+<meta property="og:locale" content="{{ .Site.Language.Lang }}">
+<meta name="twitter:card" content="summary">
+<meta name="theme-color" content="#0b5fff">

--- a/layouts/partials/theme-toggle.html
+++ b/layouts/partials/theme-toggle.html
@@ -1,0 +1,1 @@
+<button class="theme-toggle" data-theme-toggle title="Toggle theme">Theme</button>

--- a/static/favicon.svg
+++ b/static/favicon.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="64" height="64" fill="currentColor" role="img" aria-label="SolidResume">
+  <rect x="8" y="8" width="48" height="48" rx="8" ry="8"/>
+</svg>


### PR DESCRIPTION
## Summary
- add Hugo configuration and translations for English and Norwegian
- include sample CV data and theme-aware styles
- build base templates, partials, and favicon for SolidResume

## Testing
- `hugo --minify` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68ad3323e71483248e70e4f11fc82aec