### PR TITLE
feat: configure theme via Hugo params

### DIFF
--- a/assets/css/print.css
+++ b/assets/css/print.css
@@ -2,7 +2,7 @@
   :root { --bg: #ffffff; --fg: #000000; --border: #000000; }
   body { background: var(--bg); color: var(--fg); }
   a { color: inherit; text-decoration: none; }
-  .theme-toggle, .no-print { display: none !important; }
+  .no-print { display: none !important; }
   @page { size: A4; margin: 12mm; }
   .container { max-width: none; padding: 0; }
 }

--- a/assets/css/site.css
+++ b/assets/css/site.css
@@ -34,10 +34,6 @@ h1, h2, h3 { line-height:1.25; margin: 1.25rem 0 .5rem; }
 .meta { color: var(--muted); font-size: .9rem; }
 .list { margin: .5rem 0 0 0; padding-left: 1.25rem; }
 .badge { display:inline-block; border:1px solid var(--border); border-radius:.5rem; padding:.15rem .5rem; margin:.15rem; font-size:.85rem; }
-.theme-toggle {
-  border:1px solid var(--border); background: transparent; color: var(--fg);
-  border-radius:.5rem; padding:.4rem .6rem; cursor: pointer;
-}
 @media (max-width: 600px){
   .container { margin: 1rem auto; }
 }

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -30,7 +30,7 @@
           {{ with $cv.profile.location }}{{ . }}{{ end }}
         </div>
       </div>
-      {{ partial "theme-toggle.html" . }}
+      {{/* theme toggle removed: color scheme configured in config */}}
     </header>
 
     {{ block "main" . }}{{ end }}
@@ -40,23 +40,11 @@
 
   <script>
     (function(){
-      const key = "cv-theme";
       const root = document.documentElement;
-      const btn = document.querySelector('[data-theme-toggle]');
-      function apply(mode){
-        if(mode === "light"){ root.style.colorScheme = "light"; }
-        else if(mode === "dark"){ root.style.colorScheme = "dark"; }
-        else { root.style.colorScheme = ""; } // auto
-      }
-      const saved = localStorage.getItem(key) || "auto";
-      apply(saved);
-      if(btn){
-        btn.addEventListener('click', () => {
-          const next = saved === "light" ? "dark" : saved === "dark" ? "auto" : "light";
-          localStorage.setItem(key, next);
-          location.reload();
-        });
-      }
+      const mode = "{{ .Site.Params.colorScheme | default "auto" }}";
+      if(mode === "light"){ root.style.colorScheme = "light"; }
+      else if(mode === "dark"){ root.style.colorScheme = "dark"; }
+      else { root.style.colorScheme = ""; } // auto
     })();
   </script>
 </body>

--- a/layouts/partials/theme-toggle.html
+++ b/layouts/partials/theme-toggle.html
@@ -1,1 +1,0 @@
-<button class="theme-toggle" data-theme-toggle title="Toggle theme">Theme</button>


### PR DESCRIPTION
## Summary
- remove theme toggle button partial and JS
- read `colorScheme` from Hugo config to set theme
- drop unused `.theme-toggle` styles

## Testing
- `hugo` *(fails: command not found)*
- `apt-get update` *(fails: repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68ad37d918148324beb6e2ee1ce05bf3