### PR TITLE
feat: add language switcher to resume header

### DIFF
--- a/assets/css/site.css
+++ b/assets/css/site.css
@@ -32,6 +32,7 @@ header { display:flex; justify-content: space-between; align-items: center; gap:
 h1, h2, h3 { line-height:1.25; margin: 1.25rem 0 .5rem; }
 .section { padding: 1rem 0; border-top: 1px solid var(--border); }
 .meta { color: var(--muted); font-size: .9rem; }
+.lang-switcher { font-size: .9rem; }
 .list { margin: .5rem 0 0 0; padding-left: 1.25rem; }
 .badge { display:inline-block; border:1px solid var(--border); border-radius:.5rem; padding:.15rem .5rem; margin:.15rem; font-size:.85rem; }
 @media (max-width: 600px){

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -30,6 +30,15 @@
           {{ with $cv.profile.location }}{{ . }}{{ end }}
         </div>
       </div>
+      {{ $current := .Site.Language.Lang }}
+      {{ $alternates := where .Sites "Language.Lang" "ne" $current }}
+      {{ if gt (len $alternates) 0 }}
+      <nav class="lang-switcher">
+        {{ range $i, $lang := $alternates }}
+          <a href="{{ $lang.Home.RelPermalink }}">{{ $lang.Language.LanguageName }}</a>{{ if lt (add $i 1) (len $alternates) }} · {{ end }}
+        {{ end }}
+      </nav>
+      {{ end }}
       {{/* theme toggle removed: color scheme configured in config */}}
     </header>
 


### PR DESCRIPTION
## Summary
- add conditional language switcher in header
- style language switcher text

## Testing
- `hugo --minify` *(fails: command not found)*
- `apt-get update` *(fails: repository 403)*

------
https://chatgpt.com/codex/tasks/task_e_68ad3a260fcc83249ec0ec1b1269d2ab